### PR TITLE
Added Keep Alive Response Checking

### DIFF
--- a/src/jquery-idleTimeout-plus.js
+++ b/src/jquery-idleTimeout-plus.js
@@ -67,7 +67,9 @@
     keepAliveUrl:      window.location.href,  // set URL to ping - does not apply if keepAliveInterval: false
     keepAliveAjaxType: 'GET',
     keepAliveAjaxData: '',
-
+    keepAliveResponse: 'OK',                  // add ability to check keep alive's response. if user was logged out by other means, or something went wrong, redirect to keepAliveBadUrl - Set to false to disable KeepAliveBadUrl redirection
+    keepAliveBadUrl:    window.location.href,  // set URL to redirect to if keepAliveResponse wasnt what was expected and if keepAliveResponse isn't set to false
+    
     // Lock Screen settings
     lockEnabled:          false,                      // Set to true to enable lock screen before redirecting
     lockTimeLimit:        7200,                       // 2 hrs
@@ -421,7 +423,12 @@
       $.ajax({
         type: config.keepAliveAjaxType,
         url:  config.keepAliveUrl,
-        data: config.keepAliveAjaxData
+        data: config.keepAliveAjaxData,
+        success: function(response){
+                if($.trim(response) !== config.keepAliveResponse && config.keepAliveResponse !== false){
+                        window.location.replace(config.keepAliveBadUrl);
+                }
+        }
       });
     }, config.keepAliveInterval);
   }

--- a/src/jquery-idleTimeout-plus.js
+++ b/src/jquery-idleTimeout-plus.js
@@ -67,8 +67,8 @@
     keepAliveUrl:      window.location.href,  // set URL to ping - does not apply if keepAliveInterval: false
     keepAliveAjaxType: 'GET',
     keepAliveAjaxData: '',
-    keepAliveResponse: 'OK',                  // add ability to check keep alive's response. if user was logged out by other means, or something went wrong, redirect to keepAliveBadUrl - Set to false to disable KeepAliveBadUrl redirection
-    keepAliveBadUrl:    window.location.href,  // set URL to redirect to if keepAliveResponse wasnt what was expected and if keepAliveResponse isn't set to false
+    keepAliveResponse: false,                  // add ability to check keep alive's response. if user was logged out by other means, or something went wrong, redirect to keepAliveBadUrl - Set to false to disable KeepAliveBadUrl redirection
+    keepAliveBadUrl:    window.location.href,  // set URL to redirect to if keepAliveResponse wasn't what was expected and if keepAliveResponse isn't set to false
     
     // Lock Screen settings
     lockEnabled:          false,                      // Set to true to enable lock screen before redirecting
@@ -425,7 +425,7 @@
         url:  config.keepAliveUrl,
         data: config.keepAliveAjaxData,
         success: function(response){
-                if($.trim(response) !== config.keepAliveResponse && config.keepAliveResponse !== false){
+                if(config.keepAliveResponse !== false && $.trim(response) !== config.keepAliveResponse){
                         window.location.replace(config.keepAliveBadUrl);
                 }
         }


### PR DESCRIPTION
I wanted to add the ability to actually check the response of the keep alive polling.

Like other jQuery-idle-Timeout versions (specifically @ehynds 's version https://github.com/ehynds/jquery-idle-timeout)

Added variable 'keepAliveResponse'
If 'keepAliveResponse' is set to false, response is ignored/disregarded (like it already was prior to this PR).
If 'keepAliveResponse' is set to a string (eg. 'OK') then the ajax response from keepAliveUrl is verified against the string. If its different, then the user is redirected to 'keepAliveBadUrl'

Added variable 'keepAliveBadUrl' to set a given URL to redirect to if the above 'keepAliveResponse' is set to anything other than false.

This is useful if you are using the polling of keepAliveUrl to check on settings (in my example, I verify the user's session still exists, if it does I return "OK" if it doesn't I return "ERROR" prompting the redirect to the login page). You could also use this to check on other critical information and redirect to an error page. keepAliveBadUrl could even be modified to show a model dialog window or something.